### PR TITLE
chore: set base path for Vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
+    base: '/Eastleigh_Turf_Grass/',
     server: { port: 5173, strictPort: true },
     preview: { port: 5174, strictPort: true },
     resolve: {


### PR DESCRIPTION
## Summary
- specify base path for Vite builds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b54dffdd2883218c5fcf682b15e115